### PR TITLE
Move initial message to on_client_ready handler for the client/server…

### DIFF
--- a/server/bot.py
+++ b/server/bot.py
@@ -172,14 +172,14 @@ Important guidelines:
     async def on_client_ready(rtvi):
         logger.debug("Client ready event received")
         await rtvi.set_bot_ready()
+        # Kick off the conversation
+        await task.queue_frames([context_aggregator.user().get_context_frame()])
 
     @transport.event_handler("on_first_participant_joined")
     async def on_first_participant_joined(transport, participant):
         logger.info("First participant joined: {}", participant["id"])
         # Capture the participant's transcription
         await transport.capture_participant_transcription(participant["id"])
-        # Kick off the conversation
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
 
     @transport.event_handler("on_participant_left")
     async def on_participant_left(transport, participant, reason):


### PR DESCRIPTION
… bot

This ensures that the bot doesn't start speaking until the client is ready to receive audio.